### PR TITLE
add linting to passing requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,14 @@
     "prepublishOnly": "npm run cleanBuild && npm run test && npm run buildTypeDocs",
     "clean": "rm -rf ./dist",
     "build": "tsc",
-    "lint": "tslint 'src/**/*.ts'",
+    "lint": "tslint src/**/*.ts && tslint test/BotTestFailure.spec.ts",
     "lint:fix": "tslint 'src/**/*.ts' --fix",
     "cleanBuild": "npm run clean && npm run build",
     "watch": "tsc -w",
     "test": "node_modules/mocha/bin/_mocha --require node_modules/ts-node/register test/*.spec.ts",
-    "buildTypeDocs": "yarn cleanBuild && typedoc --excludeNotExported --out docs --hideGenerator src/BotTester.ts --module commonjs --gaID UA-105358964-1 --readme none"
+    "buildTypeDocs": "yarn cleanBuild && typedoc --excludeNotExported --out docs --hideGenerator src/BotTester.ts --module commonjs --gaID UA-105358964-1 --readme none && touch docs/.nojekyll",
+    "ci": "npm run lint && npm run test"
+
   },
   "dependencies": {
     "bluebird": "^3.5.0",
@@ -60,7 +62,7 @@
     "chai-as-promised": "^7.1.1",
     "mocha": "^3.4.2",
     "ts-node": "^3.1.0",
-    "tslint": "^5.4.3",
+    "tslint": "^5.7.0",
     "typescript": "^2.4.1"
   },
   "files": [

--- a/test/BotTesterFailure.spec.ts
+++ b/test/BotTesterFailure.spec.ts
@@ -61,11 +61,13 @@ describe('BotTester', () => {
     }
 
     it('will fail if response to a prompt is not as expected', (done: Function) => {
+        //tslint:disable
         bot.dialog('/', [(session: Session) => {
             new Prompts.text(session, 'Hi there! Tell me something you like');
         }, (session: Session, results: IDialogResult<string>) => {
             session.send(`${results.response} is pretty cool.`);
             new Prompts.text(session, 'Why do you like it?');
+        //tslint:enable
         }, (session: Session) => session.send('Interesting. Well, that\'s all I have for now')]);
 
         expect(new BotTester(bot)
@@ -78,7 +80,9 @@ describe('BotTester', () => {
 
     xit('NOT SURE HOW TO TEST THIS ONE, IF AT ALLcan inspect session state', () => {
         bot.dialog('/', [(session: Session) => {
+            //tslint:disable
             new Prompts.text(session, 'What would you like to set data to?');
+            //tslint:enable
         }, (session: Session, results: IDialogResult<string>) => {
             session.userData = { data: results.response };
             session.save();
@@ -87,8 +91,10 @@ describe('BotTester', () => {
         return new BotTester(bot)
             .sendMessageToBot('Start this thing!',  'What would you like to set data to?')
             .sendMessageToBotAndExpectSaveWithNoResponse('This is data!')
-            .checkSession((session) => {
+            .checkSession((session: Session) => {
+                //tslint:disable
                 expect(session.userData).not.to.be.null;
+                //tslint:enable
                 expect(session.userData.data).to.be.equal('This is data!');
             })
             .runTest();

--- a/tslint.json
+++ b/tslint.json
@@ -53,7 +53,7 @@
     "no-duplicate-case": true,
     "no-duplicate-super": true,
     "no-duplicate-variable": true,
-    "no-empty": true,
+    "no-empty": false,
     "no-floating-promises": true,
     "no-for-in-array": true,
     "no-import-side-effect": true,
@@ -279,5 +279,7 @@
     "no-switch-case-fall-through": false,
     "typeof-compare": false
   },
-  "rulesDirectory": "./"
+  "rulesDirectory": [
+    "./"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -784,9 +784,9 @@ tslib@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 
-tslint@^5.4.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.4.3.tgz#761c8402b80e347b7733a04390a757b253580467"
+tslint@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.7.0.tgz#c25e0d0c92fa1201c2bc30e844e08e682b4f3552"
   dependencies:
     babel-code-frame "^6.22.0"
     colors "^1.1.2"
@@ -797,11 +797,13 @@ tslint@^5.4.3:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.7.1"
-    tsutils "^2.3.0"
+    tsutils "^2.8.1"
 
-tsutils@^2.3.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.4.0.tgz#ad4ce6dba0e5a3edbddf8626b7ca040782189fea"
+tsutils@^2.8.1:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.2.tgz#2c1486ba431260845b0ac6f902afd9d708a8ea6a"
+  dependencies:
+    tslib "^1.7.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
I'm not linting BotTester.spec.ts because of how big of a PIA dealing with the no unused expressions w/ chai is. Just check that manually with your linter in an IDE (for now).

Also added .nojekyll generation in docs directory to allow git pages to work properly